### PR TITLE
Another bluespace miner nerf

### DIFF
--- a/modular_sand/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/modular_sand/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -40,7 +40,7 @@
 		/obj/item/stock_parts/micro_laser = 5,
 		/obj/item/stock_parts/manipulator = 5,
 		/obj/item/stock_parts/scanning_module = 5,
-		/obj/item/stack/ore/bluespace_crystal = 10)
+		/obj/item/stack/ore/bluespace_crystal = 15) //nostra change - from 5 to 15
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/telecomms/message_server

--- a/modular_sand/code/modules/mining/machine_bluespaceminer.dm
+++ b/modular_sand/code/modules/mining/machine_bluespaceminer.dm
@@ -30,7 +30,7 @@
 		multiplier += L.rating
 		stock_amt++
 	multiplier /= stock_amt
-	if(multiplier >= 5)
+	if(multiplier >= 5) //nostra comment - doesnt matter after nerf
 		ore_rates += list(/datum/material/bluespace = 0.01)
 	else
 		ore_rates -= ore_rates["bluespace crystal"]
@@ -60,7 +60,7 @@
 	if(!mat_container || panel_open || !powered())
 		return
 	var/datum/material/ore = pick(ore_rates)
-	mat_container.bsm_insert(((ore_rates[ore] * 1000) * multiplier * 0.5), ore)
+	mat_container.bsm_insert(((ore_rates[ore] * 1000) * multiplier * 0.5), ore) //nostra change - added '* 0.5' because fun is not allowed
 
 /datum/component/material_container/proc/bsm_insert(amt, datum/material/mat)
 	if(!istype(mat))


### PR DESCRIPTION
## About The Pull Request

N oㅤf u nㅤa l l o w e d

## Why It's Good For The Game

Lazy miners goes brrrrr x2
Bluespace tech making bluespace crystals should make the tear in the fabric of reality tho.
(Remember, you can craft bluespace crystals using diamonds.. 
Not like it changes anything, maybe later I'll try to make something better/more original)

With dedication to Nor and Roentgenium.

## Changelog
:cl:
balance: bluespace miner crafting cost is changed from 10 to 15
balance: tier 5 bluespace miner is generating 5x more diamonds
balance: tier 5 bluespace miner isn't generating bluespace crystals anymore
/:cl: