### PR TITLE
Adds Jerry, Jerry's bed and Citrus to cargo, also minor fixes.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_nostra.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_nostra.dmm
@@ -6457,10 +6457,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/brig)
-"ama" = (
-/mob/living/simple_animal/sloth/paperwork,
-/turf/open/floor/plasteel,
-/area/cargo/storage)
 "amb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32150,7 +32146,13 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/holopad/secure,
+/mob/living/simple_animal/hostile/carp/cargo{
+	icon_state = "cargo_carp"
+	},
+/obj/structure/bed/dogbed/ian{
+	desc = "A bed for carp.";
+	name = "Jerry's bed"
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "byD" = (
@@ -32733,6 +32735,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad/secure,
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "bzR" = (
@@ -56856,6 +56859,13 @@
 "kQk" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
+"kQq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/sloth/citrus,
+/turf/open/floor/plasteel,
+/area/cargo/storage)
 "kQz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -83271,8 +83281,8 @@ dev
 aZE
 xBw
 bjr
-ama
-bmh
+bjr
+kQq
 bjr
 bjr
 bjr

--- a/_maps/map_files/DIYstation/DIYstation.dmm
+++ b/_maps/map_files/DIYstation/DIYstation.dmm
@@ -5877,6 +5877,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/carp/cargo{
+	icon_state = "cargo_carp"
+	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "FU" = (
@@ -9183,6 +9186,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	dir = 4
 	},
+/mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "Xa" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_nostra.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_nostra.dmm
@@ -25889,7 +25889,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/mob/living/simple_animal/sloth/citrus,
+/obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "aVU" = (
@@ -25899,8 +25900,13 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/holopad/secure,
+/obj/structure/bed/dogbed/ian{
+	desc = "A bed for carp.";
+	name = "Jerry's bed"
+	},
+/mob/living/simple_animal/hostile/carp/cargo{
+	icon_state = "cargo_carp"
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "aVV" = (
@@ -28355,8 +28361,7 @@
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2;
-	
+	luminosity = 2
 	},
 /area/security/prison)
 "aZP" = (
@@ -29976,8 +29981,7 @@
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2;
-	
+	luminosity = 2
 	},
 /area/security/prison)
 "bcX" = (
@@ -125259,6 +125263,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"eNI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/mob/living/simple_animal/sloth/citrus,
+/turf/open/floor/plasteel,
+/area/cargo/storage)
 "eTv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -172182,7 +172200,7 @@ azy
 azy
 aAG
 aKQ
-azy
+eNI
 aNv
 aOW
 axf

--- a/_maps/map_files/MetaStation/MetaStation_nostra.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_nostra.dmm
@@ -44869,6 +44869,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTg" = (
@@ -56871,6 +56878,9 @@
 /area/cargo/warehouse)
 "iiK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/mob/living/simple_animal/hostile/carp/cargo{
+	icon_state = "cargo_carp"
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "iiP" = (
@@ -62052,6 +62062,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
+"ljz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/mob/living/simple_animal/sloth/citrus,
+/turf/open/floor/plasteel,
+/area/cargo/storage)
 "ljM" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -65544,12 +65559,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"nwc" = (
-/mob/living/simple_animal/hostile/carp/cargo{
-	icon_state = "cargo_carp"
-	},
-/turf/open/floor/plasteel,
-/area/cargo/storage)
 "nwG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -101391,7 +101400,7 @@ mIE
 mIE
 ifM
 mIE
-nwc
+mIE
 wzm
 hZC
 tUN
@@ -101902,7 +101911,7 @@ mKW
 qKo
 mKW
 dRx
-mKW
+ljz
 nUn
 mKW
 mXL

--- a/_maps/map_files/OmegaStation/OmegaStation_nostra.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation_nostra.dmm
@@ -5440,12 +5440,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
-"ajf" = (
-/mob/living/simple_animal/hostile/carp/cargo{
-	icon_state = "cargo_carp"
-	},
-/turf/open/floor/plasteel,
-/area/cargo/storage)
 "ajg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -31936,7 +31930,8 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/tritium,
-/obj/machinery/door/window/southleft{
+/obj/machinery/door/window/brigdoor{
+	desc = "Door that leads to green heaven.";
 	name = "DANGER";
 	req_access_txt = "30"
 	},
@@ -34573,6 +34568,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -44041,6 +44040,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/oldomega/OldAtmos)
+"hCD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/carp/cargo{
+	icon_state = "cargo_carp"
+	},
+/turf/open/floor/plasteel/dark,
+/area/cargo/storage)
 "hCU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -45512,6 +45523,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plasteel/dark,
 /area/cargo/warehouse)
 "kTr" = (
@@ -46018,7 +46030,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "meo" = (
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/rust,
 /area/science/mixing)
 "mfj" = (
 /obj/machinery/holopad,
@@ -46810,6 +46822,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "ohM" = (
@@ -98794,7 +98810,7 @@ uIG
 rDW
 rDW
 aii
-ajf
+aeW
 ajQ
 rDW
 rDW
@@ -99311,7 +99327,7 @@ ahm
 jOR
 amy
 amy
-amy
+hCD
 amy
 cXQ
 fIU
@@ -103214,13 +103230,13 @@ eGm
 bdI
 gcw
 bgi
-sVt
+iio
 qcP
-sVt
+iio
 meo
 meo
-sVt
-sVt
+iio
+iio
 kFk
 owp
 owp

--- a/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
@@ -24068,6 +24068,13 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/bed/dogbed/ian{
+	desc = "A bed for carp.";
+	name = "Jerry's bed"
+	},
+/mob/living/simple_animal/hostile/carp/cargo{
+	icon_state = "cargo_carp"
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "bdG" = (
@@ -53729,6 +53736,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"esn" = (
+/mob/living/simple_animal/sloth/citrus,
+/turf/open/floor/plasteel,
+/area/cargo/storage)
 "eta" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -102604,7 +102615,7 @@ aTl
 aUw
 aTm
 aTm
-aTm
+esn
 aYy
 aZo
 baB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Jerry, Jerry's bed and Citrus to cargo.

## Why It's Good For The Game

It's not.

## A Port?

It's not.

## Changelog
:cl:
add: Added Jerry and Citrus to cargo on Box, DIY, Delta, Meta, Omega and PubbyStation.
add: Added Jerry's bed on some stations.
fix: Added missing creature pen windoor on MetaStation.
tweak: Reinforced "DANGER" windoor on OmegaStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
