### PR TITLE
Update PubbyStation_nostra.dmm

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_nostra.dmm
@@ -27,10 +27,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "aaf" = (
@@ -38,18 +34,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "aag" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
@@ -58,10 +46,6 @@
 "aah" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "aai" = (
@@ -69,20 +53,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "aaj" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -105,6 +81,10 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
+	},
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -20141,18 +20121,18 @@
 	pixel_x = -32;
 	pixel_y = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aVg" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/service/bar)
 "aVh" = (
 /obj/structure/table/glass,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/drinks/bottle/patron{
 	pixel_x = -5;
 	pixel_y = 16
@@ -20172,7 +20152,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aVi" = (
 /obj/structure/table/glass,
@@ -20209,7 +20189,7 @@
 	pixel_x = -10;
 	pixel_y = 15
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aVj" = (
 /obj/machinery/disposal/bin,
@@ -20224,7 +20204,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aVk" = (
 /obj/structure/table/wood,
@@ -20611,22 +20591,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aWj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aWl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aWm" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aWn" = (
 /obj/machinery/power/apc{
@@ -21044,7 +21024,7 @@
 /area/service/bar)
 "aXh" = (
 /obj/effect/landmark/start/bartender,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "aXk" = (
 /obj/structure/disposalpipe/segment{
@@ -21552,6 +21532,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "aYf" = (
@@ -21564,6 +21547,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "aYg" = (
@@ -21573,6 +21559,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
@@ -21585,6 +21574,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
@@ -21600,6 +21592,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
@@ -34017,6 +34012,9 @@
 /area/command/heads_quarters/rd)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "bAu" = (
@@ -34428,7 +34426,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/rd)
@@ -34514,13 +34512,21 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBx" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -34542,7 +34548,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -34664,13 +34670,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -34680,11 +34686,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bBO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35294,12 +35300,21 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -35327,8 +35342,8 @@
 /area/science/storage)
 "bCQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/storage)
 "bCR" = (
@@ -35712,6 +35727,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bDI" = (
@@ -35720,6 +35738,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -36443,6 +36464,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/pipe_dispenser/science,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/rd)
 "bEV" = (
@@ -36578,6 +36600,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
+/obj/item/pipe_dispenser/science,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFj" = (
@@ -36933,11 +36956,20 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bGc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "bGd" = (
@@ -38238,11 +38270,11 @@
 /area/hallway/primary/aft)
 "bIF" = (
 /obj/structure/tank_dispenser,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light,
 /turf/open/floor/engine,
 /area/science/storage)
 "bIG" = (
@@ -38271,10 +38303,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
 "bIJ" = (
@@ -38282,11 +38314,11 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light,
 /turf/open/floor/engine,
 /area/science/storage)
 "bIK" = (
@@ -39241,15 +39273,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -39261,17 +39287,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bKU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -39347,14 +39367,10 @@
 	dir = 8;
 	name = "Mix Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bKZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -39379,11 +39395,8 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bLc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	frequency = 1441;
-	id_tag = "mix_in";
-	name = "distro out"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -39759,16 +39772,10 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bLZ" = (
 /obj/machinery/meter/atmos/atmos_waste_loop,
@@ -39840,6 +39847,9 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bMf" = (
@@ -39855,30 +39865,23 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bMh" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 8;
-	input_tag = "mix_in";
-	name = "Gas Mix Tank Control";
-	output_tag = "mix_in";
-	sensors = list("mix_sensor" = "Tank")
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bMi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
 "bMj" = (
-/obj/machinery/air_sensor{
-	id_tag = "mix_sensor"
-	},
+/obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "bMk" = (
@@ -40359,17 +40362,21 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bNl" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
+"bNl" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bNm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -40386,11 +40393,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "bNo" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8;
-	frequency = 1441;
-	id = "mix_in";
-	pixel_y = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -40772,7 +40776,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bOl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -40782,7 +40786,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bOm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -40813,6 +40817,10 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Pure to Mix"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -41087,6 +41095,10 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bPe" = (
@@ -41094,12 +41106,11 @@
 	dir = 8;
 	name = "N2O Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bPf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -41110,11 +41121,8 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bPg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	frequency = 1441;
-	id_tag = "n2o_out";
-	name = "n2o out"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
+	dir = 8
 	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
@@ -41339,9 +41347,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bPP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -41349,10 +41354,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bPQ" = (
 /turf/closed/wall,
@@ -41396,22 +41398,21 @@
 /area/engineering/atmos)
 "bPW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bPX" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 8;
-	input_tag = "n2o_in";
-	name = "Nitrous Oxide Supply Control";
-	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
+/area/engineering/atmos)
+"bPX" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bPY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -41419,9 +41420,7 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bPZ" = (
-/obj/machinery/air_sensor{
-	id_tag = "n2o_sensor"
-	},
+/obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bQa" = (
@@ -41780,15 +41779,14 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bQM" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
 	name = "Unfiltered to Mix"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bQO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -41799,11 +41797,8 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bQP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8;
-	frequency = 1441;
-	id = "n2o_in";
-	pixel_y = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
+	dir = 8
 	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
@@ -42099,17 +42094,11 @@
 /area/engineering/atmos)
 "bRx" = (
 /obj/machinery/computer/atmos_control,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bRy" = (
 /obj/structure/closet/secure_closet/atmospherics,
@@ -42119,18 +42108,11 @@
 	name = "Atmos RC";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bRz" = (
 /obj/structure/disposalpipe/segment,
@@ -42148,12 +42130,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bRC" = (
 /obj/structure/lattice,
@@ -42425,38 +42407,30 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bSd" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bSe" = (
 /obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bSf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -42465,19 +42439,15 @@
 	dir = 8;
 	name = "Plasma Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bSj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	frequency = 1441;
-	id_tag = "tox_out";
-	name = "toxin out"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
+	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
@@ -42743,14 +42713,13 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bSR" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bSS" = (
 /obj/structure/chair/office/dark,
@@ -42764,17 +42733,13 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bSU" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -42783,24 +42748,17 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bSV" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 8;
-	input_tag = "tox_in";
-	name = "Plasma Supply Control";
-	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bSW" = (
-/obj/machinery/air_sensor{
-	id_tag = "tox_sensor"
-	},
+/obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSX" = (
@@ -43193,14 +43151,11 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Entrance"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/pipedispenser,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bTL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -43209,30 +43164,27 @@
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/pipedispenser/disposal,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bTM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bTN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bTO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -43240,10 +43192,6 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bTP" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
 	},
@@ -43251,7 +43199,10 @@
 	c_tag = "Atmospherics Starboard";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bTQ" = (
 /obj/machinery/door/poddoor/preopen{
@@ -43288,11 +43239,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bTV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8;
-	frequency = 1441;
-	id = "tox_in";
-	pixel_y = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
+	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
@@ -43466,6 +43414,10 @@
 	dir = 9
 	},
 /obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bUs" = (
@@ -43476,10 +43428,18 @@
 	dir = 1;
 	name = "O2 to Pure"
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bUt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bUu" = (
@@ -43488,6 +43448,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -43507,32 +43471,30 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bUy" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bUz" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bUA" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
+"bUA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bUC" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -43882,17 +43844,15 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bVh" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bVi" = (
@@ -43916,12 +43876,11 @@
 	dir = 8;
 	name = "CO2 Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bVl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44245,15 +44204,14 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bWb" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bWc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44584,22 +44542,17 @@
 /turf/closed/wall,
 /area/engineering/break_room)
 "bWI" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bWJ" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -44613,6 +44566,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bWP" = (
@@ -44620,11 +44578,22 @@
 	dir = 1;
 	name = "Air to Pure"
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bWQ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -44813,117 +44782,105 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "bXr" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Waste to Space"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bXs" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
+"bXs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXt" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXu" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXw" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bXx" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
+"bXx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXA" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXB" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXC" = (
 /obj/machinery/light,
@@ -44931,12 +44888,11 @@
 	dir = 4;
 	name = "Air Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXD" = (
 /obj/structure/cable{
@@ -44945,11 +44901,10 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -44958,26 +44913,22 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "bXG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -45667,7 +45618,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZi" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -45794,7 +45744,7 @@
 /area/engineering/main)
 "bZG" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45817,7 +45767,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "bZK" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/components/unary/relief_valve/atmos/atmos_waste{
 	dir = 1
 	},
@@ -45918,10 +45867,6 @@
 "bZU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
-	},
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = 32;
-	pixel_y = -32
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -46143,11 +46088,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/igniter/incinerator_atmos,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
-"caP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/air_sensor/atmos/incinerator_tank{
+	pixel_x = 32;
+	pixel_y = -32
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -47216,6 +47159,10 @@
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
@@ -49700,9 +49647,6 @@
 /area/service/bar)
 "cpb" = (
 /obj/structure/table/glass,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/drinks/bottle/goldschlager{
 	pixel_x = -8;
 	pixel_y = 15
@@ -49723,15 +49667,18 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/camera{
+	c_tag = "Bar Drinks"
+	},
+/turf/open/floor/wood,
 /area/service/bar)
 "cpc" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Bar Drinks"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "cpe" = (
 /obj/machinery/door/airlock{
@@ -50257,6 +50204,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "cqH" = (
@@ -51795,6 +51743,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library/lounge)
+"cwt" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "cww" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
@@ -52821,10 +52777,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cBT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "cBU" = (
 /turf/closed/wall/r_wall,
 /area/command/gateway)
@@ -52983,6 +52935,10 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"cNy" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -53435,10 +53391,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "dEy" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/reflector/double/anchored{
 	dir = 9
 	},
@@ -53482,10 +53434,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dJk" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "dJm" = (
@@ -53664,6 +53614,16 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"eha" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "ehM" = (
 /obj/effect/decal/remains/human,
 /obj/structure/disposaloutlet,
@@ -53705,6 +53665,12 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"eoW" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release"
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "epj" = (
 /obj/machinery/cryopod/tele,
 /turf/open/floor/plasteel,
@@ -53758,6 +53724,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"etZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "euQ" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -53814,9 +53789,6 @@
 "eAZ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /turf/open/space,
 /area/space/nearstation)
 "eCw" = (
@@ -53983,13 +53955,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"eSX" = (
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	network = list("turbine")
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -54748,9 +54713,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gAD" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/lattice,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "gAG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -54983,6 +54952,10 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"hat" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "haA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -55293,9 +55266,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"hLC" = (
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -56076,6 +56046,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"juJ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "juO" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -56160,6 +56134,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"jzN" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "jAy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56359,11 +56343,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "kaR" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
@@ -56660,6 +56644,19 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"kHz" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Turbine Chamber";
+	dir = 5;
+	network = list("turbine")
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "kIo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -57058,6 +57055,16 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"lFl" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "lGp" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel/dark,
@@ -57146,6 +57153,14 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lQh" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "lQn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -57349,7 +57364,7 @@
 /area/engineering/main)
 "mjn" = (
 /obj/machinery/jukebox,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/service/bar)
 "mjK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -57666,6 +57681,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engineering/main)
+"ncs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/science)
 "ndI" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/plating{
@@ -58342,6 +58364,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"oyJ" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "ozO" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
@@ -58531,6 +58557,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/miningdock)
+"oQd" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oRX" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -58810,6 +58843,10 @@
 	dir = 1;
 	name = "N2 to Pure"
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "pnU" = (
@@ -58822,9 +58859,8 @@
 /area/science/xenobiology)
 "poP" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -59963,7 +59999,10 @@
 	dir = 4
 	},
 /obj/machinery/pipedispenser/disposal/transit_tube,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "rNB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60135,6 +60174,20 @@
 "sqQ" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"sri" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/science)
 "srZ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -60211,6 +60264,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"szi" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "szG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -60239,15 +60300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sEv" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engineering/main)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -60737,11 +60789,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/cargo/warehouse)
-"tMr" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/maintenance/disposal/incinerator)
 "tOD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -60842,14 +60889,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"udl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60966,6 +61005,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"unj" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "uny" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -61111,6 +61157,14 @@
 "uzu" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uAB" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -61157,6 +61211,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"uIW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/space,
+/area/space/nearstation)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -61403,6 +61462,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"vtk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -61418,6 +61483,10 @@
 "vtT" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"vuj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/service/bar)
 "vuP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -61827,6 +61896,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wwc" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62349,10 +62422,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"xqJ" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/turf/open/floor/engine/vacuum,
-/area/space)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating,
@@ -62437,6 +62506,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"xBR" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/bar)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -62462,8 +62535,8 @@
 /area/hallway/primary/aft)
 "xEx" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/storage)
 "xFl" = (
@@ -92906,7 +92979,7 @@ bZA
 can
 cbi
 ccc
-aac
+eyj
 cdR
 aaf
 bXk
@@ -93162,7 +93235,7 @@ bYR
 bZA
 can
 cbj
-aac
+eyj
 cbX
 wcs
 iyJ
@@ -93676,7 +93749,7 @@ bYT
 bZB
 caq
 cbk
-aac
+eyj
 ccY
 cdT
 ccY
@@ -93933,7 +94006,7 @@ bYU
 bZE
 car
 mgz
-aac
+eyj
 cbX
 wcs
 wcs
@@ -94648,7 +94721,7 @@ coW
 aPE
 aVg
 aWj
-bah
+aSP
 aYf
 aZc
 bah
@@ -94904,8 +94977,8 @@ aKY
 coW
 aPE
 aVh
-bah
-bah
+aSP
+aSP
 aYg
 cph
 bag
@@ -94961,7 +95034,7 @@ bYQ
 bZA
 cam
 mgz
-aac
+eyj
 tlV
 wcs
 wcs
@@ -95161,7 +95234,7 @@ aKY
 coW
 aPE
 aVi
-bah
+aSP
 aXh
 aYg
 aZd
@@ -95218,7 +95291,7 @@ wjm
 bZF
 cbm
 mgz
-aac
+eyj
 oHa
 oHa
 eWi
@@ -95418,8 +95491,8 @@ aRX
 aST
 aPE
 cpb
-bah
-bah
+aSP
+aSP
 aYg
 cpi
 bag
@@ -95676,7 +95749,7 @@ aQN
 aPE
 cpc
 aWl
-beB
+vuj
 aYh
 cpj
 bah
@@ -95732,7 +95805,7 @@ bYY
 bZA
 cam
 cbn
-aac
+eyj
 cbX
 wcs
 cfP
@@ -95933,7 +96006,7 @@ aQN
 aPE
 aVj
 aWm
-bck
+xBR
 aYi
 cpk
 bag
@@ -95990,7 +96063,7 @@ bZG
 cax
 cbo
 dCT
-sEv
+aah
 rKg
 aag
 bXq
@@ -96510,13 +96583,13 @@ cam
 haA
 frj
 aal
-eyj
+aac
 uIB
-eyj
-eyj
+aac
+aac
 uIB
-eyj
-eyj
+aac
+aac
 bXk
 bXk
 bXk
@@ -97013,13 +97086,13 @@ bJN
 bJN
 bJN
 bJN
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
 frj
-pYh
-pYh
-pYh
-pYh
-pYh
-pYh
 pYh
 pYh
 hUw
@@ -97269,14 +97342,14 @@ bVe
 bUp
 bWI
 bXr
-bKQ
-udl
+eoW
+acN
 bZK
 abI
 abI
 abI
 abI
-aht
+oQd
 aaa
 cdm
 aht
@@ -97527,13 +97600,13 @@ bMf
 bWJ
 bXs
 bJN
-cui
-bJP
-bJP
-bJP
-bJP
-bJP
 abI
+bJP
+bJP
+bJP
+bJP
+bJP
+cui
 abI
 gBb
 nyr
@@ -97781,7 +97854,7 @@ bTJ
 bMf
 bMf
 bMf
-bMf
+bWJ
 bXt
 bYp
 eAZ
@@ -97790,7 +97863,7 @@ caz
 cbs
 cbs
 bJP
-aht
+oQd
 aaa
 qvr
 nyr
@@ -98015,7 +98088,7 @@ byC
 bvA
 bxj
 hiY
-bAt
+sri
 bBx
 bCL
 bDH
@@ -98038,16 +98111,16 @@ bTK
 bMf
 bMf
 bMf
-bMf
+bWJ
 bXu
 bLW
-cui
+abI
 bMi
 caA
 cbt
 ccm
 bJP
-aht
+oQd
 aht
 gBb
 nyr
@@ -98272,7 +98345,7 @@ buu
 bvB
 bxk
 byK
-bAt
+ncs
 bBy
 bCM
 bDI
@@ -98295,7 +98368,7 @@ bTL
 bMf
 bMf
 bMf
-bWM
+jzN
 bXv
 bVh
 poP
@@ -98304,7 +98377,7 @@ caB
 cbs
 cbs
 bJP
-aht
+oQd
 aaa
 qvr
 dJx
@@ -98531,8 +98604,8 @@ bxl
 cqt
 bAu
 bAu
-bAt
-bAt
+ncs
+ncs
 bAu
 bAu
 bHp
@@ -98555,13 +98628,13 @@ hjk
 pmB
 bXw
 dJk
-cui
+unj
 bJP
 bJP
 bJP
 bJP
 bJP
-aht
+oQd
 aaa
 aaa
 aht
@@ -98802,14 +98875,14 @@ bOm
 bOU
 bPS
 bSf
-bUp
+etZ
 bTM
-bUp
+vtk
 bTN
 bMf
 bMf
 bVZ
-bOX
+lFl
 bUA
 bYp
 eAZ
@@ -98818,7 +98891,7 @@ caC
 cbu
 cbu
 bJP
-aht
+oQd
 aht
 fon
 fon
@@ -99059,23 +99132,23 @@ bQJ
 bOV
 bMf
 bMf
-bMf
-bMf
-bMf
-bMf
+lQh
+uAB
+cwt
+szi
 bMf
 bMf
 bVZ
-bOX
+lFl
 bXx
 bVi
-cui
+abI
 bMi
 caD
 cbv
 ccn
 bJP
-aht
+oQd
 aaa
 fon
 shH
@@ -99326,13 +99399,13 @@ bVY
 bUs
 bVg
 bVm
-poP
+uIW
 bZL
 caE
 cbu
 cbu
 bJP
-aht
+oQd
 aht
 fon
 fon
@@ -99580,16 +99653,16 @@ bMf
 bMf
 bMf
 bVZ
-bOX
+lFl
 kas
 bNm
-cui
+abI
 bJP
 bJP
 bJP
 bJP
 bJP
-aht
+oQd
 aaa
 aaa
 aaa
@@ -99840,13 +99913,13 @@ bVZ
 bWO
 bXA
 bQO
-poP
+uIW
 bZM
 caF
 cbw
 cby
 bJP
-aht
+oQd
 aaa
 aaa
 fon
@@ -100094,16 +100167,16 @@ bMf
 bMf
 bMf
 bVZ
-bMf
+bWJ
 bXB
 bNm
-cui
+abI
 bMi
 caG
 cbx
 cco
 bJP
-aht
+oQd
 aht
 aht
 fon
@@ -100353,14 +100426,14 @@ bMf
 bVY
 bWP
 bXy
-bQO
-poP
+bVm
+uIW
 bZN
 caH
 cby
 cby
 bJP
-aht
+oQd
 aaa
 aaa
 fon
@@ -100611,13 +100684,13 @@ bTR
 bUt
 bXC
 bYs
+juJ
+juJ
+juJ
+juJ
+juJ
+juJ
 bVW
-bYw
-bYw
-cBT
-bYw
-bYw
-bYw
 aht
 aht
 fon
@@ -101109,7 +101182,7 @@ bCR
 bIH
 bHw
 cqG
-bOX
+eha
 bNk
 bOq
 bPd
@@ -102410,7 +102483,7 @@ bWe
 bWT
 bJP
 aht
-bYw
+oyJ
 bZU
 caO
 cbF
@@ -102668,10 +102741,10 @@ bVo
 bJP
 aht
 bYw
-eSX
-caP
-hLC
-tMr
+bYw
+juO
+bYw
+bYw
 cdm
 cdm
 bYw
@@ -102924,14 +102997,14 @@ bWg
 bVo
 bJP
 aaa
+cdm
 bYw
+caQ
 bYw
-juO
-bYw
-bYw
+cdm
 aaa
 aaa
-aaa
+mau
 aaa
 aaa
 aaa
@@ -103181,14 +103254,14 @@ bJP
 bJP
 bJP
 abI
-aaa
-bYw
-caQ
-bYw
-aaa
-aaa
-aaa
-aaa
+ahi
+cNy
+wwc
+cNy
+cdm
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -103438,14 +103511,14 @@ aaa
 aaa
 abI
 aaa
-abI
+cdm
+kHz
+aaa
 gAD
-xqJ
-gAD
+cdm
 aaa
 aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -103694,15 +103767,15 @@ aby
 aby
 aby
 aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hat
+cdm
+cdm
+cdm
+cdm
+cdm
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -103952,14 +104025,14 @@ abI
 aaa
 aaa
 aaa
+aht
+aaa
+aht
+aaa
+aht
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -104208,15 +104281,15 @@ acO
 aby
 bzy
 aaa
+aht
+mau
+fon
+fon
+fon
+fon
+aht
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mau
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

hf

## Why It's Good For The Game

fdh

## A Port?

dfh

## Changelog
:cl:
fix: Improved and fixed gas chambers consoles on PubbyStation.
tweak: Added empty canisters and more portable vent pumps and scrubbers in atmos on PubbyStation.
tweak: Moved pipe leading to SM from atmos little bit down on PubbyStation.
tweak: Added layer manifold from O2 outlet on PubbyStation.
tweak: Changed few tiles in atmos on PubbyStation to dark ones because fuck you thats why. 
tweak: Turbine on PubbyStation was made a little bit smaller.
fix: Fixed lack of floor under the vent blastdoor in turbine on PubbyStation.
tweak: Moved vent blastdoor to the upper section of turbine on PubbyStation.
fix: Fixed visible scrubber manifold in engineering on PubbyStation.
tweak: Removed few blastdoors in engineering on PubbyStation.
tweak: Added few blastdoors in engineering on PubbyStation.
tweak: Moved engineering air alarm to the left to prevent it being destroyed by emitter on basic setup on PubbyStation.
fix: Fixed lack of cable knot under the RD office APC on PubbyStation.
add: Added Science RPD in RD office on PubbyStation.
add: Added Science RPD in Toxins on PubbyStation.
tweak: Changed metal floor tiles to wooden ones behind the bar on the PubbyStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
