### PR TITLE
No More Snootless Lizards! Also additional customization options too the Magic Mirror.

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -141,7 +141,7 @@
 
 	var/mob/living/carbon/human/H = user
 
-	var/choice = input(user, "Something to change?", "Magical Grooming") as null|anything in list("name", "race", "gender", "hair", "eyes", "legs", "tail")
+	var/choice = input(user, "Something to change?", "Magical Grooming") as null|anything in list("name", "race", "gender", "hair", "eyes", "legs", "tail") // Nostra change - added legs and tail
 
 	if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
@@ -203,7 +203,7 @@
 					else
 						to_chat(H, "<span class='notice'>Invalid color. Your color is not bright enough.</span>")
 
-			if(racechoice == SPECIES_LIZARD || racechoice == SPECIES_ASHWALKER)
+			if(racechoice == SPECIES_LIZARD || racechoice == SPECIES_ASHWALKER) // Nostra change
 				H.dna.features["frills"] = "None"
 				H.dna.features["tail_lizard"] = "Smooth"
 
@@ -280,6 +280,7 @@
 					H.dna.update_ui_block(DNA_RIGHT_EYE_COLOR_BLOCK)
 					H.dna.species.handle_body()
 
+		/* Start of Nostra change */
 		if("legs")
 			var/legchoice = alert(H, "Choose a leg style.", "Legs", "Plantigrade", "Digitigrade")
 			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
@@ -332,6 +333,7 @@
 						H.update_body()
 						H.update_body_parts()
 					return
+		/* End of Nostra change */
 
 	if(choice)
 		curse(user)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -141,7 +141,7 @@
 
 	var/mob/living/carbon/human/H = user
 
-	var/choice = input(user, "Something to change?", "Magical Grooming") as null|anything in list("name", "race", "gender", "hair", "eyes")
+	var/choice = input(user, "Something to change?", "Magical Grooming") as null|anything in list("name", "race", "gender", "hair", "eyes", "legs", "tail")
 
 	if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
@@ -202,6 +202,10 @@
 
 					else
 						to_chat(H, "<span class='notice'>Invalid color. Your color is not bright enough.</span>")
+
+			if(racechoice == SPECIES_LIZARD || racechoice == SPECIES_ASHWALKER)
+				H.dna.features["frills"] = "None"
+				H.dna.features["tail_lizard"] = "Smooth"
 
 			H.update_body()
 			H.update_hair()
@@ -275,6 +279,60 @@
 					H.dna.update_ui_block(DNA_LEFT_EYE_COLOR_BLOCK)
 					H.dna.update_ui_block(DNA_RIGHT_EYE_COLOR_BLOCK)
 					H.dna.species.handle_body()
+
+		if("legs")
+			var/legchoice = alert(H, "Choose a leg style.", "Legs", "Plantigrade", "Digitigrade")
+			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+				return
+			if(legchoice)
+				H.dna.features["legs"] = legchoice
+				if(legchoice == "Digitigrade")
+					H.dna.species.species_traits |= DIGITIGRADE
+				else
+					H.dna.species.species_traits -= DIGITIGRADE
+				H.Digitigrade_Leg_Swap(legchoice == "Digitigrade" ? FALSE : TRUE)
+				H.update_body()
+			return
+
+		if("tail")
+			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+				return
+			switch(H.dna.species.id)
+				if(SPECIES_LIZARD)
+					var/new_lizard_tail = input(user, "Select a lizard tail style.", "Tails")  as null|anything in GLOB.tails_list_lizard
+					if(new_lizard_tail)
+						H.dna.features["tail_lizard"] = new_lizard_tail
+						H.update_body()
+						H.update_body_parts()
+					return
+				if(SPECIES_ASHWALKER)
+					var/new_lizard_tail = input(user, "Select a lizard tail style.", "Tails")  as null|anything in GLOB.tails_list_lizard
+					if(new_lizard_tail)
+						H.dna.features["tail_lizard"] = new_lizard_tail
+						H.update_body()
+						H.update_body_parts()
+					return
+				if(SPECIES_MAMMAL)
+					var/new_mammal_tail = input(user, "Select a mammal tail style.", "Tails")  as null|anything in GLOB.mam_tails_list
+					if(new_mammal_tail)
+						H.dna.features["tail_mammal"] = new_mammal_tail
+						H.update_body()
+						H.update_body_parts()
+					return
+				if(SPECIES_XENOHYBRID)
+					to_chat(H, span_warning("This race has no alternative tail options!")) //So I just thought of something very cursed... VSC Battle Roya- *Bzzt* *Thud* *Thud*
+					return
+				if(SPECIES_PLASMAMAN)
+					to_chat(H, span_warning("This race has no alternative tail options!")) //So I just thought of something very cursed... VSC Battle Roya- *Bzzt* *Thud* *Thud*
+					return
+				else
+					var/new_tail = input(user, "Select a tail style.", "Tails") as null|anything in GLOB.tails_list_human
+					if(new_tail)
+						H.dna.features["tail_human"] = new_tail
+						H.update_body()
+						H.update_body_parts()
+					return
+
 	if(choice)
 		curse(user)
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -45,12 +45,6 @@
 
 	return randname
 
-/datum/species/lizard/on_species_gain(mob/living/carbon/human/C)
-	if(C.dna.features["mam_snouts"] == "None")
-		C.dna.features["mam_snouts"] = "Sharp"
-		C.update_body()
-	return ..()
-
 /*
  Lizard subspecies: ASHWALKERS
 */

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -45,6 +45,12 @@
 
 	return randname
 
+/datum/species/lizard/on_species_gain(mob/living/carbon/human/C)
+	if(C.dna.features["mam_snouts"] == "None")
+		C.dna.features["mam_snouts"] = "Sharp"
+		C.update_body()
+	return ..()
+
 /*
  Lizard subspecies: ASHWALKERS
 */

--- a/modular_nostra/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/modular_nostra/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -1,0 +1,5 @@
+/datum/species/lizard/on_species_gain(mob/living/carbon/human/C)
+	if(C.dna.features["mam_snouts"] == "None")
+		C.dna.features["mam_snouts"] = "Sharp"
+		C.update_body()
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3823,6 +3823,7 @@
 #include "modular_nostra\code\modules\mob\living\carbon\gunpoint\gunpoint_datum.dm"
 #include "modular_nostra\code\modules\mob\living\carbon\gunpoint\gunpoint_radial.dm"
 #include "modular_nostra\code\modules\mob\living\carbon\human\species.dm"
+#include "modular_nostra\code\modules\mob\living\carbon\human\species_types\lizardpeople.dm"
 #include "modular_nostra\code\modules\mob\living\silicon\ai\ai.dm"
 #include "modular_nostra\code\modules\mob\living\silicon\ai\freelook\eye.dm"
 #include "modular_nostra\code\modules\mob\living\simple_animal\hostile\cargo_carp.dm"


### PR DESCRIPTION
NO MORE SNOOTLESS LIZARDS!!!! Cause my GOD do they look so cursed without a snoot.

Also the Magic Mirror should be able to change your legs- And actually give an option for tails as well. Cause it just didn't make sense that wasn't a thing already.

## About The Pull Request

Makes Lizards always have a snout, also adding more customization features to the Magic Mirror.

## Why It's Good For The Game

Snoutless Lizards will not exist, and this is a good thing. Cause my god it was so cursed seeing Lizards without a snout.
Also people would love more customization options to the Magic Mirror.

## A Port?

Nope!

## Changelog
:cl:
add: Additional Mirror Customization Options
tweak: Lizards will now always have snouts.
/:cl:
